### PR TITLE
Add sample size entry to list for 32bps streams

### DIFF
--- a/flac.tcl
+++ b/flac.tcl
@@ -1048,7 +1048,7 @@ namespace eval ::flac {
                 4 {list 16 16}
                 5 {list 20 20}
                 6 {list 24 24}
-                7 {list "reserved" 0}
+                7 {list 32 32}
             }
         }] _desc sample_size
 


### PR DESCRIPTION
First of all, many thanks for developing and pointing me to this FLAC decoder. It helped me to prove a point I made in the flac specification:

https://github.com/ietf-wg-cellar/flac-specification/blob/6abc108bccba9e7a985e8ad3ee2b94f3280c3f73/rfc_backmatter.md?plain=1#L8

Specifically

> Choosing a 64-bit signed data type for all arithmetic involving sample values would make sure the possibility for overflow is eliminated

At least, I think flac.tcl proves this. I have zero knowledge of Tcl and hadn't even heard of it before encountering this project, but looking at the project and skimming through the list of 'Tcl features' it seems all calculations here are done with at least 64 bit signed ints. Please let me know if I'm wrong.

Anyway, I've recently integrated a 32 bps encoder/decoder into FLAC and have submitted patches for ffmpeg. These patches were rather large, but for flac.tcl I only had to add the sample size to the correct table, after which everything seems to work correctly. I've checked `fq` as well and stumbled upon the issue that reading of entropy partitions with 'raw bits' doesn't properly work yet (I might look into that myself), but otherwise adding a sample size entry is enough to get it working. I'll submit a PR for that as well.

Once again: many thanks! Having a decoder (counting fq its actually two) that simply works on 32bps FLAC without any changes because it hasn't been designed to use 32-bit signed ints where possible was very valuable in proving that the implementation is correct.